### PR TITLE
Default gpio

### DIFF
--- a/allocated-gpio/allocated-gpio.c
+++ b/allocated-gpio/allocated-gpio.c
@@ -130,16 +130,28 @@ static void create_pin_attrs(struct platform_device *pdev)
 			continue;
 		}
 		printk(KERN_INFO "GPIO #%d = %s\n", gpio, child->name);
+		data->attr_array[num_attrs].gpio = gpio;
+
 		data->attr_array[num_attrs].n.attr.name = child->name;
 		data->attr_array[num_attrs].n.attr.mode = S_IRUGO;
 		data->attr_array[num_attrs].n.show = gpio_state_show;
-		//TODO: check dt param for input/output
-		if (1)
+
+		if (of_property_read_bool(child, "output-low"))
+		{
+			printk(KERN_INFO "Setting GPIO low\n");
+			gpio_direction_output(data->attr_array[num_attrs].gpio, 0);
+		}
+		else if (of_property_read_bool(child, "output-high"))
+		{
+			printk(KERN_INFO "Setting GPIO high\n");
+			gpio_direction_output(data->attr_array[num_attrs].gpio, 1);
+		}
+
+		if (! of_property_read_bool(child, "input") )
 		{
 			data->attr_array[num_attrs].n.store = gpio_state_store;
 			data->attr_array[num_attrs].n.attr.mode = S_IWUGO | S_IRUGO;
 		}
-		data->attr_array[num_attrs].gpio = gpio;
 		data->attr_list[num_attrs] = &data->attr_array[num_attrs].n.attr;
 		num_attrs++;
 	}

--- a/version.sh
+++ b/version.sh
@@ -7,7 +7,7 @@ cat <<EOF > ${FILE}
 #ifndef _VERSION_H_
 #define _VERSION_H_
 
-#define GIT_DESCRIBE  "${GIT_DESCRIBE}"
+#define GIT_DESCRIBE  "${GIT_DESCRIBE}-b${BUILD_NUMBER}"
 #define BUILD_DATE    "${BUILD_DATE}"
 #endif //_VERSION_H_
 EOF


### PR DESCRIPTION
Allow specifying a default value in the device tree.  This allows 'enable_analog' or 'fpga_analog' to come up in a working state.